### PR TITLE
Adding Main 2 and Aux 2

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,10 @@
             </div>
             <ul class="filters__list">
                 <li class="filters__list-item">
+                    <input class="filters__input js_criteria js_keyword js_compile" type="checkbox" id="compile" name="checkbox" value="1">
+                    <label class="filters__label" for="compile">Compile</label>
+                </li>
+                <li class="filters__list-item">
                     <input class="filters__input js_criteria js_keyword js_delete" type="checkbox" id="delete" name="checkbox" value="1">
                     <label class="filters__label" for="delete">Delete</label>
                 </li>
@@ -106,12 +110,24 @@
                     <label class="filters__label" for="shift">Shift</label>
                 </li>
                 <li class="filters__list-item">
+                    <input class="filters__input js_criteria js_keyword js_shuffle" type="checkbox" id="shuffle" name="checkbox" value="1">
+                    <label class="filters__label" for="shuffle">Shuffle</label>
+                </li>
+                <li class="filters__list-item">
                     <input class="filters__input js_criteria js_keyword js_swap" type="checkbox" id="swap" name="checkbox" value="1">
                     <label class="filters__label" for="swap">Swap</label>
                 </li>
                 <li class="filters__list-item">
                     <input class="filters__input js_criteria js_keyword js_take" type="checkbox" id="take" name="checkbox" value="1">
                     <label class="filters__label" for="take">Take</label>
+                </li>
+                <li class="filters__list-item">
+                    <input class="filters__input js_criteria js_keyword js_top-deck" type="checkbox" id="top-deck" name="checkbox" value="1">
+                    <label class="filters__label" for="top-deck">Top-deck</label>
+                </li>
+                <li class="filters__list-item">
+                    <input class="filters__input js_criteria js_keyword js_trash" type="checkbox" id="trash" name="checkbox" value="1">
+                    <label class="filters__label" for="trash">Trash</label>
                 </li>
             </ul>
         </div>

--- a/index.html
+++ b/index.html
@@ -15,68 +15,7 @@
                 <button class="filters__btn js_select-all-protocol">Select All</button>
                 <button class="filters__btn js_remove-all-protocol">Remove All</button>
             </div>
-            <ul class="filters__list">
-                <li class="filters__list-item">
-                    <input class="filters__input js_criteria js_protocol js_apathy" checked type="checkbox" id="apathy" name="checkbox" value="1">
-                    <label class="filters__label" for="apathy">Apathy</label>
-                </li>
-                <li class="filters__list-item">
-                    <input class="filters__input js_criteria js_protocol js_darkness" checked type="checkbox" id="darkness" name="checkbox" value="1">
-                    <label class="filters__label" for="darkness">Darkness</label>
-                </li>
-                <li class="filters__list-item">
-                    <input class="filters__input js_criteria js_protocol js_death" checked type="checkbox" id="death" name="checkbox" value="1">
-                    <label class="filters__label" for="death">Death</label>
-                </li>
-                <li class="filters__list-item">
-                    <input class="filters__input js_criteria js_protocol js_fire" checked type="checkbox" id="fire" name="checkbox" value="1">
-                    <label class="filters__label" for="fire">Fire</label>
-                </li>
-                <li class="filters__list-item">
-                    <input class="filters__input js_criteria js_protocol js_gravity" checked type="checkbox" id="gravity" name="checkbox" value="1">
-                    <label class="filters__label" for="gravity">Gravity</label>
-                </li>
-                <li class="filters__list-item">
-                    <input class="filters__input js_criteria js_protocol js_hate" checked type="checkbox" id="hate" name="checkbox" value="1">
-                    <label class="filters__label" for="hate">Hate</label>
-                </li>
-                <li class="filters__list-item">
-                    <input class="filters__input js_criteria js_protocol js_life" checked type="checkbox" id="life" name="checkbox" value="1">
-                    <label class="filters__label" for="life">Life</label>
-                </li>
-                <li class="filters__list-item">
-                    <input class="filters__input js_criteria js_protocol js_light" checked type="checkbox" id="light" name="checkbox" value="1">
-                    <label class="filters__label" for="light">Light</label>
-                </li>
-                <li class="filters__list-item">
-                    <input class="filters__input js_criteria js_protocol js_love" checked type="checkbox" id="love" name="checkbox" value="1">
-                    <label class="filters__label" for="love">Love</label>
-                </li>
-                <li class="filters__list-item">
-                    <input class="filters__input js_criteria js_protocol js_metal" checked type="checkbox" id="metal" name="checkbox" value="1">
-                    <label class="filters__label" for="metal">Metal</label>
-                </li>
-                <li class="filters__list-item">
-                    <input class="filters__input js_criteria js_protocol js_plague" checked type="checkbox" id="plague" name="checkbox" value="1">
-                    <label class="filters__label" for="plague">Plague</label>
-                </li>
-                <li class="filters__list-item">
-                    <input class="filters__input js_criteria js_protocol js_psychic" checked type="checkbox" id="psychic" name="checkbox" value="1">
-                    <label class="filters__label" for="psychic">Psychic</label>
-                </li>
-                <li class="filters__list-item">
-                    <input class="filters__input js_criteria js_protocol js_speed" checked type="checkbox" id="speed" name="checkbox" value="1">
-                    <label class="filters__label" for="speed">Speed</label>
-                </li>
-                <li class="filters__list-item">
-                    <input class="filters__input js_criteria js_protocol js_spirit" checked type="checkbox" id="spirit" name="checkbox" value="1">
-                    <label class="filters__label" for="spirit">Spirit</label>
-                </li>
-                <li class="filters__list-item">
-                    <input class="filters__input js_criteria js_protocol js_water" checked type="checkbox" id="water" name="checkbox" value="1">
-                    <label class="filters__label" for="water">Water</label>
-                </li>
-            </ul>
+            <ul class="filters__list js_protocol-list"></ul>
         </div>
         <div class="filters__filter">
             <h2 class="filters__title">Value</h2>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
             <div class="filters__btn-container">
                 <button class="filters__btn js_select-all-protocol">Select All</button>
                 <button class="filters__btn js_remove-all-protocol">Remove All</button>
+                <button class="filters__btn js_expand-all-programs">Expand All</button>
+                <button class="filters__btn js_collapse-all-programs">Collapse All</button>
             </div>
             <ul class="filters__list js_protocol-list"></ul>
         </div>
@@ -64,6 +66,10 @@
                 <li class="filters__list-item">
                     <input class="filters__input js_criteria js_keyword js_compile" type="checkbox" id="compile" name="checkbox" value="1">
                     <label class="filters__label" for="compile">Compile</label>
+                </li>
+                <li class="filters__list-item">
+                    <input class="filters__input js_criteria js_keyword js_control" type="checkbox" id="control" name="checkbox" value="1">
+                    <label class="filters__label" for="control">Control</label>
                 </li>
                 <li class="filters__list-item">
                     <input class="filters__input js_criteria js_keyword js_delete" type="checkbox" id="delete" name="checkbox" value="1">

--- a/script.js
+++ b/script.js
@@ -975,11 +975,733 @@ let cards = [
             discard: true,
         }
     },
+    {
+        protocol: "Chaos",
+        value: 0,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Chaos",
+        value: 1,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Chaos",
+        value: 2,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Chaos",
+        value: 3,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Chaos",
+        value: 4,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Chaos",
+        value: 5,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Clarity",
+        value: 0,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Clarity",
+        value: 1,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Clarity",
+        value: 2,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Clarity",
+        value: 3,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Clarity",
+        value: 4,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Clarity",
+        value: 5,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Corruption",
+        value: 0,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Corruption",
+        value: 1,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Corruption",
+        value: 2,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Corruption",
+        value: 3,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Corruption",
+        value: 4,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Corruption",
+        value: 5,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Courage",
+        value: 0,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Courage",
+        value: 1,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Courage",
+        value: 2,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Courage",
+        value: 3,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Courage",
+        value: 4,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Courage",
+        value: 5,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Fear",
+        value: 0,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Fear",
+        value: 1,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Fear",
+        value: 2,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Fear",
+        value: 3,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Fear",
+        value: 4,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Fear",
+        value: 5,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Ice",
+        value: 0,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Ice",
+        value: 1,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Ice",
+        value: 2,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Ice",
+        value: 3,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Ice",
+        value: 4,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Ice",
+        value: 5,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Luck",
+        value: 0,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Luck",
+        value: 1,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Luck",
+        value: 2,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Luck",
+        value: 3,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Luck",
+        value: 4,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Luck",
+        value: 5,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Mirror",
+        value: 0,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Mirror",
+        value: 1,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Mirror",
+        value: 2,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Mirror",
+        value: 3,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Mirror",
+        value: 4,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Mirror",
+        value: 5,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Peace",
+        value: 0,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Peace",
+        value: 1,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Peace",
+        value: 2,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Peace",
+        value: 3,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Peace",
+        value: 4,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Peace",
+        value: 5,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Smoke",
+        value: 0,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Smoke",
+        value: 1,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Smoke",
+        value: 2,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Smoke",
+        value: 3,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Smoke",
+        value: 4,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Smoke",
+        value: 5,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Time",
+        value: 0,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Time",
+        value: 1,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Time",
+        value: 2,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Time",
+        value: 3,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Time",
+        value: 4,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Time",
+        value: 5,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "War",
+        value: 0,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "War",
+        value: 1,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "War",
+        value: 2,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "War",
+        value: 3,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "War",
+        value: 4,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "War",
+        value: 5,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Diversity",
+        value: 0,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Diversity",
+        value: 1,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Diversity",
+        value: 2,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Diversity",
+        value: 3,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Diversity",
+        value: 4,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Diversity",
+        value: 5,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Assimilation",
+        value: 0,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Assimilation",
+        value: 1,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Assimilation",
+        value: 2,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Assimilation",
+        value: 3,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Assimilation",
+        value: 4,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Assimilation",
+        value: 5,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Unity",
+        value: 0,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Unity",
+        value: 1,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Unity",
+        value: 2,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Unity",
+        value: 3,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Unity",
+        value: 4,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
+    {
+        protocol: "Unity",
+        value: 5,
+        top: "",
+        middle: "",
+        bottom: "",
+        keywords: {}
+    },
 ]
 
 const programs = {
     "Main 1": ["Darkness", "Death", "Fire", "Gravity", "Life", "Light", "Metal", "Plague", "Psychic", "Speed", "Spirit", "Water"],
-    "Aux 1": ["Apathy", "Hate", "Love"]
+    "Aux 1": ["Apathy", "Hate", "Love"],
+    "Main 2": ["Chaos", "Clarity", "Corruption", "Courage", "Fear", "Ice", "Luck", "Mirror", "Peace", "Smoke", "Time", "War"],
+    "Aux 2": ["Diversity", "Assimilation", "Unity"]
 };
 
 initialize();

--- a/script.js
+++ b/script.js
@@ -933,14 +933,20 @@ let cards = [
     },
 ]
 
+const programs = {
+    "Main 1": ["Darkness", "Death", "Fire", "Gravity", "Life", "Light", "Metal", "Plague", "Psychic", "Speed", "Spirit", "Water"],
+    "Aux 1": ["Apathy", "Hate", "Love"]
+};
+
 initialize();
 
 function initialize() {
+    buildProtocolFilter();
     let array = cards;
     displayCards(array);
 }
 
-$(".js_protocol").click(function() {
+$(document).on('click', '.js_protocol', function() {
     checkFilters();
 })
 $(".js_value").click(function() {
@@ -974,16 +980,65 @@ $(".js_remove-all-keywords").click(function() {
     checkFilters();
 })
 
+$(document).on('click', '.js_collapse-program', function() {
+    const targetId = $(this).data('target');
+    const $list = $('#' + targetId);
+    $list.toggleClass('filters__program-list--collapsed');
+    $(this).html($list.hasClass('filters__program-list--collapsed') ? '&#9654;' : '&#9660;');
+});
+
+$(document).on('click', '.js_select-all-program', function() {
+    $(this).closest('.filters__program').find('.js_protocol').prop('checked', true);
+    checkFilters();
+});
+
+$(document).on('click', '.js_remove-all-program', function() {
+    $(this).closest('.filters__program').find('.js_protocol').prop('checked', false);
+    checkFilters();
+});
+
+function buildProtocolFilter() {
+    const $list = $('.js_protocol-list');
+    $list.empty();
+
+    Object.entries(programs).forEach(([programName, protocols]) => {
+        const programId = programName.toLowerCase().replace(/\s+/g, '-');
+        const listId = `program-list-${programId}`;
+
+        const protocolItems = protocols.map(protocol => {
+            const protocolLower = protocol.toLowerCase();
+            return `
+                <li class="filters__list-item">
+                    <input class="filters__input js_criteria js_protocol js_${protocolLower}" checked type="checkbox" id="${protocolLower}" name="checkbox" value="1" data-protocol="${protocol}">
+                    <label class="filters__label" for="${protocolLower}">${protocol}</label>
+                </li>`;
+        }).join('');
+
+        $list.append(`
+            <li class="filters__program">
+                <div class="filters__program-header">
+                    <button class="filters__collapse-btn js_collapse-program" data-target="${listId}">&#9660;</button>
+                    <span class="filters__program-name">${programName}</span>
+                    <div class="filters__program-btns">
+                        <button class="filters__btn filters__btn--sm js_select-all-program">Select All</button>
+                        <button class="filters__btn filters__btn--sm js_remove-all-program">Remove All</button>
+                    </div>
+                </div>
+                <ul class="filters__program-list" id="${listId}">
+                    ${protocolItems}
+                </ul>
+            </li>`);
+    });
+}
+
 function checkFilters() {
     let array = cards;
-
-    let [apathy, darkness, death, fire, gravity, hate, life, light, love, metal, plague, psychic, speed, spirit, water] = checkProtocols();
 
     let [zero, one, two, three, four, five, six] = checkValue();
 
     let [deleteVar, discard, draw, flip, give, play, rearrange, returnVar, reveal, refresh, shift, swap, take] = checkKeywords();
 
-    array = getProtocols(array, apathy, darkness, death, fire, gravity, hate, life, light, love, metal, plague, psychic, speed, spirit, water);
+    array = getProtocols(array);
 
     array = getValue(array, zero, one, two, three, four, five, six);
 
@@ -992,25 +1047,6 @@ function checkFilters() {
     displayCards(array);
 }
 
-function checkProtocols() {
-    let apathy = $('.js_apathy').is(':checked');
-    let darkness = $('.js_darkness').is(':checked');
-    let death = $('.js_death').is(':checked');
-    let fire = $('.js_fire').is(':checked');
-    let gravity = $('.js_gravity').is(':checked');
-    let hate = $('.js_hate').is(':checked');
-    let life = $('.js_life').is(':checked');
-    let light = $('.js_light').is(':checked');
-    let love = $('.js_love').is(':checked');
-    let metal = $('.js_metal').is(':checked');
-    let plague = $('.js_plague').is(':checked');
-    let psychic = $('.js_psychic').is(':checked');
-    let speed = $('.js_speed').is(':checked');
-    let spirit = $('.js_spirit').is(':checked');
-    let water = $('.js_water').is(':checked');
-
-    return [apathy, darkness, death, fire, gravity, hate, life, light, love, metal, plague, psychic, speed, spirit, water];
-};
 
 function checkValue() {
     let zero = $('.js_zero').is(':checked');
@@ -1042,54 +1078,12 @@ function checkKeywords() {
     return [deleteVar, discard, draw, flip, give, play, rearrange, returnVar, reveal, refresh, shift, swap, take];
 }
 
-function getProtocols(array, apathy, darkness, death, fire, gravity, hate, life, light, love, metal, plague, psychic, speed, spirit, water) {
-    if (!apathy) {
-        array = array.filter(cards => cards.protocol != "Apathy");
-    }
-    if (!darkness) {
-        array = array.filter(cards => cards.protocol != "Darkness");
-    }
-    if (!death) {
-        array = array.filter(cards => cards.protocol != "Death");
-    }
-    if (!fire) {
-        array = array.filter(cards => cards.protocol != "Fire");
-    }
-    if (!gravity) {
-        array = array.filter(cards => cards.protocol != "Gravity");
-    }
-    if (!hate) {
-        array = array.filter(cards => cards.protocol != "Hate");
-    }
-    if (!life) {
-        array = array.filter(cards => cards.protocol != "Life");
-    }
-    if (!light) {
-        array = array.filter(cards => cards.protocol != "Light");
-    }
-    if (!love) {
-        array = array.filter(cards => cards.protocol != "Love");
-    }
-    if (!metal) {
-        array = array.filter(cards => cards.protocol != "Metal");
-    }
-    if (!plague) {
-        array = array.filter(cards => cards.protocol != "Plague");
-    }
-    if (!psychic) {
-        array = array.filter(cards => cards.protocol != "Psychic");
-    }
-    if (!speed) {
-        array = array.filter(cards => cards.protocol != "Speed");
-    }
-    if (!spirit) {
-        array = array.filter(cards => cards.protocol != "Spirit");
-    }
-    if (!water) {
-        array = array.filter(cards => cards.protocol != "Water");
-    }
-
-    return array;
+function getProtocols(array) {
+    const checked = new Set();
+    $('.js_protocol:checked').each(function() {
+        checked.add($(this).data('protocol'));
+    });
+    return array.filter(card => checked.has(card.protocol));
 }
 
 function getValue(array, zero, one, two, three, four, five, six) {

--- a/script.js
+++ b/script.js
@@ -1132,7 +1132,7 @@ let cards = [
         value: 1,
         top: "",
         middle: "Return 1 card.",
-        bottom: "When a card would be returned to your opponent's hand: Put that card on top of their deck face-down instead.",
+        bottom: "<div><span class='emphasis'>When a card would be returned to your opponent's hand:</span> Put that card on top of their deck face-down instead.</div>",
         keywords: {
             return: true,
         }
@@ -1341,7 +1341,7 @@ let cards = [
     },
     {
         protocol: "Ice",
-        value: 3,
+        value: 4,
         top: "",
         middle: "",
         bottom: "This card cannot be flipped.",

--- a/script.js
+++ b/script.js
@@ -979,32 +979,39 @@ let cards = [
         protocol: "Chaos",
         value: 0,
         top: "",
-        middle: "",
-        bottom: "",
-        keywords: {}
+        middle: "In each line, flip 1 covered card.",
+        bottom: "Start: Draw the top card of your opponent's deck. Your opponent draws the top card of your deck.",
+        keywords: {
+            draw: true,
+            flip: true,
+        }
     },
     {
         protocol: "Chaos",
         value: 1,
         top: "",
-        middle: "",
+        middle: "Rearrange your protocols. Rearrange your opponent's protocols.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            rearrange: true,
+        }
     },
     {
         protocol: "Chaos",
         value: 2,
         top: "",
-        middle: "",
+        middle: "Shift 1 of your covered cards.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            shift: true,
+        }
     },
     {
         protocol: "Chaos",
         value: 3,
         top: "",
         middle: "",
-        bottom: "",
+        bottom: "This card may be played without matching protocols.",
         keywords: {}
     },
     {
@@ -1012,54 +1019,68 @@ let cards = [
         value: 4,
         top: "",
         middle: "",
-        bottom: "",
-        keywords: {}
+        bottom: "End: Discard your hand. Draw that many cards.",
+        keywords: {
+            discard: true,
+            draw: true,
+        }
     },
     {
         protocol: "Chaos",
         value: 5,
         top: "",
+        middle: "Discard 1 card.",
+        bottom: "",
+        keywords: {
+            discard: true,
+        }
+    },
+    {
+        protocol: "Clarity",
+        value: 0,
+        top: "Your total value in this line is increased by 1 for each card in your hand.",
         middle: "",
         bottom: "",
         keywords: {}
     },
     {
         protocol: "Clarity",
-        value: 0,
-        top: "",
-        middle: "",
-        bottom: "",
-        keywords: {}
-    },
-    {
-        protocol: "Clarity",
         value: 1,
-        top: "",
-        middle: "",
-        bottom: "",
-        keywords: {}
+        top: "Start: Reveal the top card of your deck. You may discard the top card of your deck.",
+        middle: "Your opponent reveals their hand.",
+        bottom: "When this card would be covered: First, draw 3 cards.",
+        keywords: {
+            draw: true,
+            reveal: true,
+        }
     },
     {
         protocol: "Clarity",
         value: 2,
         top: "",
-        middle: "",
+        middle: "Reveal your deck. Draw 1 card with a value of 1 revealed this way. Shuffle your deck. Play 1 card with a value of 1.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            draw: true,
+            reveal: true,
+        }
     },
     {
         protocol: "Clarity",
         value: 3,
         top: "",
-        middle: "",
+        middle: "Reveal your deck. Draw 1 card with a value of 5 revealed this way. Shuffle your deck.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            draw: true,
+            reveal: true,
+        }
     },
     {
         protocol: "Clarity",
         value: 4,
         top: "",
-        middle: "",
+        middle: "You may shuffle your trash into your deck.",
         bottom: "",
         keywords: {}
     },
@@ -1067,518 +1088,657 @@ let cards = [
         protocol: "Clarity",
         value: 5,
         top: "",
-        middle: "",
+        middle: "Discard 1 card.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            discard: true,
+        }
     },
     {
         protocol: "Corruption",
         value: 0,
-        top: "",
+        top: "Start: Flip 1 other face-up covered or uncovered card in this stack.",
         middle: "",
-        bottom: "",
-        keywords: {}
+        bottom: "This card may be played on either player's side without matching protocols.",
+        keywords: {
+            flip: true,
+        }
     },
     {
         protocol: "Corruption",
         value: 1,
         top: "",
-        middle: "",
-        bottom: "",
-        keywords: {}
+        middle: "Return 1 card.",
+        bottom: "When a card would be returned to your opponent's hard: Put that card on top of their deck face-down instead.",
+        keywords: {
+            return: true,
+        }
     },
     {
         protocol: "Corruption",
         value: 2,
-        top: "",
-        middle: "",
+        top: "After you discard cards: Your opponent discards 1 card.",
+        middle: "Draw 1 card. Discard 1 card.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            discard: true,
+            draw: true,
+        }
     },
     {
         protocol: "Corruption",
         value: 3,
         top: "",
-        middle: "",
+        middle: "You may flip 1 face-up covered card.",
         bottom: "",
-        keywords: {}
-    },
-    {
-        protocol: "Corruption",
-        value: 4,
-        top: "",
-        middle: "",
-        bottom: "",
-        keywords: {}
+        keywords: {
+            flip: true,
+        }
     },
     {
         protocol: "Corruption",
         value: 5,
         top: "",
+        middle: "Discard 1 card.",
+        bottom: "",
+        keywords: {
+            discard: true,
+        }
+    },
+    {
+        protocol: "Corruption",
+        value: 6,
+        top: "End: Either discard 1 card or delete this card.",
         middle: "",
         bottom: "",
-        keywords: {}
+        keywords: {
+            delete: true,
+            discard: true,
+        }
     },
     {
         protocol: "Courage",
         value: 0,
-        top: "",
-        middle: "",
-        bottom: "",
-        keywords: {}
+        top: "Start: If you have no cards in hand, draw 1 card.",
+        middle: "Draw 1 card.",
+        bottom: "End: You may discard 1 card. If you do, your opponent discards 1 card.",
+        keywords: {
+            draw: true,
+            discard: true,
+        }
     },
     {
         protocol: "Courage",
         value: 1,
         top: "",
-        middle: "",
+        middle: "Delete 1 of your opponent's card in a line where they have a higher total value than you do.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            delete: true,
+        }
     },
     {
         protocol: "Courage",
         value: 2,
         top: "",
-        middle: "",
-        bottom: "",
-        keywords: {}
+        middle: "Draw 1 card.",
+        bottom: "End: If your opponent has a higher total value than you do in this line, draw 1 card.",
+        keywords: {
+            draw: true,
+        }
     },
     {
         protocol: "Courage",
         value: 3,
         top: "",
         middle: "",
-        bottom: "",
-        keywords: {}
-    },
-    {
-        protocol: "Courage",
-        value: 4,
-        top: "",
-        middle: "",
-        bottom: "",
-        keywords: {}
+        bottom: "End: You may shift this card to the line where your opponent has their highest total value.",
+        keywords: {
+            shift: true,
+        }
     },
     {
         protocol: "Courage",
         value: 5,
         top: "",
+        middle: "Discard 1 card.",
+        bottom: "",
+        keywords: {
+            discard: true,
+        }
+    },
+    {
+        protocol: "Courage",
+        value: 6,
+        top: "End: If your opponent has a higher value in this line than you do, flip this card.",
         middle: "",
         bottom: "",
-        keywords: {}
+        keywords: {
+            flip: true,
+        }
     },
     {
         protocol: "Fear",
         value: 0,
-        top: "",
-        middle: "",
+        top: "During your turn, your opponent's cards do not have middle commands.",
+        middle: "Shift or flip 1 card.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            flip: true,
+            shift: true,
+        }
     },
     {
         protocol: "Fear",
         value: 1,
         top: "",
-        middle: "",
+        middle: "Draw 2 cards. Your opponent discards their hand and draws the amount of cards discarded minus 1.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            discard: true,
+            draw: true,
+        }
     },
     {
         protocol: "Fear",
         value: 2,
         top: "",
-        middle: "",
+        middle: "Return 1 of your opponent's cards.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            return: true,
+        }
     },
     {
         protocol: "Fear",
         value: 3,
         top: "",
-        middle: "",
+        middle: "Shift 1 of your opponent's covered or uncovered cards in this line.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            shift: true,
+        }
     },
     {
         protocol: "Fear",
         value: 4,
         top: "",
-        middle: "",
+        middle: "Your opponent discards 1 random card.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            discard: true,
+        }
     },
     {
         protocol: "Fear",
         value: 5,
         top: "",
-        middle: "",
+        middle: "Discard 1 card.",
         bottom: "",
-        keywords: {}
-    },
-    {
-        protocol: "Ice",
-        value: 0,
-        top: "",
-        middle: "",
-        bottom: "",
-        keywords: {}
+        keywords: {
+            discard: true,
+        }
     },
     {
         protocol: "Ice",
         value: 1,
         top: "",
-        middle: "",
-        bottom: "",
-        keywords: {}
+        middle: "You may shift this card.",
+        bottom: "After your opponent plays a card in this line: Your opponent discards 1 card.",
+        keywords: {
+            discard: true,
+            shift: true,
+        }
     },
     {
         protocol: "Ice",
         value: 2,
         top: "",
+        middle: "Shift 1 other card.",
+        bottom: "",
+        keywords: {
+            shift: true,
+        }
+    },
+    {
+        protocol: "Ice",
+        value: 3,
+        top: "End: If this card is covered, you may shift it.",
         middle: "",
         bottom: "",
-        keywords: {}
+        keywords: {
+            shift: true,
+        }
     },
     {
         protocol: "Ice",
         value: 3,
         top: "",
         middle: "",
-        bottom: "",
-        keywords: {}
-    },
-    {
-        protocol: "Ice",
-        value: 4,
-        top: "",
-        middle: "",
-        bottom: "",
-        keywords: {}
+        bottom: "This card cannot be flipped.",
+        keywords: {
+            flip: true,
+        }
     },
     {
         protocol: "Ice",
         value: 5,
         top: "",
+        middle: "Discard 1 card.",
+        bottom: "",
+        keywords: {
+            discard: true,
+        }
+    },
+    {
+        protocol: "Ice",
+        value: 6,
+        top: "If you have any cards in your hand, you cannot draw cards.",
         middle: "",
         bottom: "",
-        keywords: {}
+        keywords: {
+            draw: true,
+        }
     },
     {
         protocol: "Luck",
         value: 0,
         top: "",
-        middle: "",
+        middle: "State a number. Draw 3 cards. Reveal 1 card drawn with the face-up value of your stated number. You may play it.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            draw: true,
+            reveal: true,
+        }
     },
     {
         protocol: "Luck",
         value: 1,
         top: "",
-        middle: "",
+        middle: "Play the top card of your deck face-down. Flip that card, ignoring middle commands.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            flip: true,
+            play: true,
+        }
     },
     {
         protocol: "Luck",
         value: 2,
         top: "",
-        middle: "",
+        middle: "Discard the top card of your deck. Draw cards equal to the value of the discarded card.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            discard: true,
+            draw: true,
+        }
     },
     {
         protocol: "Luck",
         value: 3,
         top: "",
-        middle: "",
+        middle: "State a protocol. Discard the top card of your opponent's deck. If the discarded card matches the stated protocol, delete 1 card.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            delete: true,
+            discard: true,
+        }
     },
     {
         protocol: "Luck",
         value: 4,
         top: "",
-        middle: "",
+        middle: "Discard the top card of your deck. Delete 1 covered or uncovered card that shares a value with the discarded card.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            delete: true,
+            discard: true,
+        }
     },
     {
         protocol: "Luck",
         value: 5,
         top: "",
+        middle: "Discard 1 card.",
+        bottom: "",
+        keywords: {
+            discard: true,
+        }
+    },
+    {
+        protocol: "Mirror",
+        value: 0,
+        top: "Your total value in this line is increased by 1 for each of your opponent's cards in this line.",
         middle: "",
         bottom: "",
         keywords: {}
     },
     {
         protocol: "Mirror",
-        value: 0,
-        top: "",
-        middle: "",
-        bottom: "",
-        keywords: {}
-    },
-    {
-        protocol: "Mirror",
         value: 1,
         top: "",
         middle: "",
-        bottom: "",
+        bottom: "End: You may resolve the middle command of 1 of your opponent's cards as if it were on this card.",
         keywords: {}
     },
     {
         protocol: "Mirror",
         value: 2,
         top: "",
-        middle: "",
+        middle: "Swap all of your cards in one of your stacks with another one of your stacks.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            swap: true,
+        }
     },
     {
         protocol: "Mirror",
         value: 3,
         top: "",
-        middle: "",
+        middle: "Flip 1 of your cards. Flip 1 of your opponent's cards in the same line.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            flip: true,
+        }
     },
     {
         protocol: "Mirror",
         value: 4,
         top: "",
         middle: "",
-        bottom: "",
-        keywords: {}
+        bottom: "After your opponent draws cards: Draw 1 card.",
+        keywords: {
+            draw: true,
+        }
     },
     {
         protocol: "Mirror",
         value: 5,
         top: "",
-        middle: "",
+        middle: "Discard 1 card.",
         bottom: "",
-        keywords: {}
-    },
-    {
-        protocol: "Peace",
-        value: 0,
-        top: "",
-        middle: "",
-        bottom: "",
-        keywords: {}
+        keywords: {
+            discard: true,
+        }
     },
     {
         protocol: "Peace",
         value: 1,
         top: "",
-        middle: "",
-        bottom: "",
-        keywords: {}
+        middle: "Both players discard their hand.",
+        bottom: "End: If your hand is empty, draw 1 card.",
+        keywords: {
+            discard: true,
+            draw: true,
+        }
     },
     {
         protocol: "Peace",
         value: 2,
         top: "",
-        middle: "",
+        middle: "Draw 1 card. Play 1 card face-down.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            draw: true,
+            play: true,
+        }
     },
     {
         protocol: "Peace",
         value: 3,
         top: "",
-        middle: "",
+        middle: "You may discard 1 card. Flip 1 card that has a value greater than the number of cards in your hand.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            discard: true,
+            flip: true,
+        }
     },
     {
         protocol: "Peace",
         value: 4,
         top: "",
         middle: "",
-        bottom: "",
-        keywords: {}
+        bottom: "After you discard cards during your opponent's turn: Draw 1 card.",
+        keywords: {
+            discard: true,
+            draw: true,
+        }
     },
     {
         protocol: "Peace",
         value: 5,
         top: "",
+        middle: "Discard 1 card.",
+        bottom: "",
+        keywords: {
+            discard: true,
+        }
+    },
+    {
+        protocol: "Peace",
+        value: 6,
+        top: "",
+        middle: "If you have more than 1 card in your hand, flip this card.",
+        bottom: "",
+        keywords: {
+            flip: true,
+        }
+    },
+    {
+        protocol: "Smoke",
+        value: 0,
+        top: "",
+        middle: "Play the top card of your deck face-down in each line with a face-down card.",
+        bottom: "",
+        keywords: {
+            play: true,
+        }
+    },
+    {
+        protocol: "Smoke",
+        value: 1,
+        top: "",
+        middle: "Flip 1 of your cards. You may shift that card.",
+        bottom: "",
+        keywords: {
+            flip: true,
+            shift: true,
+        }
+    },
+    {
+        protocol: "Smoke",
+        value: 2,
+        top: "Your total value in this line is increased by 1 for each face-down card in this line.",
         middle: "",
         bottom: "",
         keywords: {}
     },
     {
         protocol: "Smoke",
-        value: 0,
-        top: "",
-        middle: "",
-        bottom: "",
-        keywords: {}
-    },
-    {
-        protocol: "Smoke",
-        value: 1,
-        top: "",
-        middle: "",
-        bottom: "",
-        keywords: {}
-    },
-    {
-        protocol: "Smoke",
-        value: 2,
-        top: "",
-        middle: "",
-        bottom: "",
-        keywords: {}
-    },
-    {
-        protocol: "Smoke",
         value: 3,
         top: "",
-        middle: "",
+        middle: "Play 1 card face-down in a line with a face-down card.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            play: true,
+        }
     },
     {
         protocol: "Smoke",
         value: 4,
         top: "",
-        middle: "",
+        middle: "Shift 1 covered face-down card.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            shift: true,
+        }
     },
     {
         protocol: "Smoke",
         value: 5,
         top: "",
-        middle: "",
+        middle: "Discard 1 card.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            discard: true,
+        }
     },
     {
         protocol: "Time",
         value: 0,
         top: "",
-        middle: "",
+        middle: "Play 1 card from your trash. Shuffle your trash into your deck.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            play: true,
+        }
     },
     {
         protocol: "Time",
         value: 1,
         top: "",
-        middle: "",
+        middle: "Flip 1 covered card. Discard your entire deck.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            discard: true,
+            flip: true,
+        }
     },
     {
         protocol: "Time",
         value: 2,
-        top: "",
-        middle: "",
+        top: "After you shuffle your deck: Draw 1 card and you may shift this card.",
+        middle: "If there are any cards in your trash, you may shuffle your trash into your deck.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            draw: true,
+            shift: true,
+        }
     },
     {
         protocol: "Time",
         value: 3,
         top: "",
-        middle: "",
+        middle: "Reveal 1 card from your trash. Play it face-down in another line.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            play: true,
+            reveal: true,
+        }
     },
     {
         protocol: "Time",
         value: 4,
         top: "",
-        middle: "",
+        middle: "Draw 2 cards. Discard 2 cards.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            discard: true,
+            draw: true,
+        }
     },
     {
         protocol: "Time",
         value: 5,
         top: "",
-        middle: "",
+        middle: "Discard 1 card.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            discard: true,
+        }
     },
     {
         protocol: "War",
         value: 0,
-        top: "",
+        top: "After you refresh: You may flip this card.",
         middle: "",
-        bottom: "",
-        keywords: {}
+        bottom: "After your opponent draws cards: You may delete 1 card.",
+        keywords: {
+            delete: true,
+            draw: true,
+            flip: true,
+        }
     },
     {
         protocol: "War",
         value: 1,
         top: "",
         middle: "",
-        bottom: "",
-        keywords: {}
+        bottom: "After your opponent refreshes: Discard any number of cards. Refresh.",
+        keywords: {
+            discard: true,
+        }
     },
     {
         protocol: "War",
         value: 2,
         top: "",
-        middle: "",
-        bottom: "",
-        keywords: {}
+        middle: "Flip 1 card.",
+        bottom: "After your opponent compiles: Your opponent discards their hand.",
+        keywords: {
+            discard: true,
+            flip: true,
+        }
     },
     {
         protocol: "War",
         value: 3,
         top: "",
-        middle: "",
-        bottom: "",
-        keywords: {}
+        middle: "Draw 1 card.",
+        bottom: "After your opponent discards cards: You may play 1 card face-down.",
+        keywords: {
+            discard: true,
+            draw: true,
+            play: true,
+        }
     },
     {
         protocol: "War",
         value: 4,
         top: "",
-        middle: "",
+        middle: "Your opponent discards 1 card.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            discard: true,
+        }
     },
     {
         protocol: "War",
         value: 5,
         top: "",
-        middle: "",
+        middle: "Discard 1 card.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            discard: true,
+        }
     },
     {
         protocol: "Diversity",
         value: 0,
         top: "",
-        middle: "",
-        bottom: "",
-        keywords: {}
+        middle: "If there are 6 different protocols on cards in the field, flip the Diversity protocol to the compiled side.",
+        bottom: "End: You may play 1 non-Diversity card in this line.",
+        keywords: {
+            flip: true,
+            play: true,
+        }
     },
     {
         protocol: "Diversity",
         value: 1,
         top: "",
-        middle: "",
+        middle: "Shift 1 card. Draw cards equal to the number of different protocols on cards in this line.",
         bottom: "",
-        keywords: {}
-    },
-    {
-        protocol: "Diversity",
-        value: 2,
-        top: "",
-        middle: "",
-        bottom: "",
-        keywords: {}
+        keywords: {
+            draw: true,
+            shift: true,
+        }
     },
     {
         protocol: "Diversity",
         value: 3,
-        top: "",
+        top: "Your total value in this line is increased by 2 if there are any non-Diversity face-up cards in this stack.",
         middle: "",
         bottom: "",
         keywords: {}
@@ -1587,23 +1747,37 @@ let cards = [
         protocol: "Diversity",
         value: 4,
         top: "",
-        middle: "",
+        middle: "Flip 1 card with a value less than the number of different protocols on cards in the field.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            flip: true,
+        }
     },
     {
         protocol: "Diversity",
         value: 5,
         top: "",
+        middle: "Discard 1 card.",
+        bottom: "",
+        keywords: {
+            discard: true,
+        }
+    },
+    {
+        protocol: "Diversity",
+        value: 6,
+        top: "End: If there are not at least 4 different protocols on cards in the field, delete this card.",
         middle: "",
         bottom: "",
-        keywords: {}
+        keywords: {
+            delete: true,
+        }
     },
     {
         protocol: "Assimilation",
         value: 0,
         top: "",
-        middle: "",
+        middle: "Put 1 of your opponent's covered or uncovered face-down cards into your hand.",
         bottom: "",
         keywords: {}
     },
@@ -1611,89 +1785,116 @@ let cards = [
         protocol: "Assimilation",
         value: 1,
         top: "",
-        middle: "",
-        bottom: "",
-        keywords: {}
+        middle: "Discard 1 card. Refresh.",
+        bottom: "After a player refreshes: Draw the top card of your opponent's deck. Discard 1 card into their trash.",
+        keywords: {
+            discard: true,
+            draw: true,
+        }
     },
     {
         protocol: "Assimilation",
         value: 2,
         top: "",
         middle: "",
-        bottom: "",
-        keywords: {}
-    },
-    {
-        protocol: "Assimilation",
-        value: 3,
-        top: "",
-        middle: "",
-        bottom: "",
-        keywords: {}
+        bottom: "End: Play the top card of your opponent's deck face-down in this stack.",
+        keywords: {
+            play: true,
+        }
     },
     {
         protocol: "Assimilation",
         value: 4,
         top: "",
-        middle: "",
+        middle: "Draw the top card of your opponent's deck. Your opponent draws the top card of your deck.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            draw: true,
+        }
     },
     {
         protocol: "Assimilation",
         value: 5,
         top: "",
-        middle: "",
+        middle: "Discard 1 card.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            discard: true,
+        }
+    },
+    {
+        protocol: "Assimilation",
+        value: 6,
+        top: "",
+        middle: "",
+        bottom: "End: Play the top card of your deck face-down on your opponent's side.",
+        keywords: {
+            play: true,
+        }
     },
     {
         protocol: "Unity",
         value: 0,
         top: "",
-        middle: "",
-        bottom: "",
-        keywords: {}
+        middle: "If there is another Unity card in the field, either flip 1 card or draw 1 card.",
+        bottom: "When this card would be covered by a Unity card: First, either flip 1 card or draw 1 card.",
+        keywords: {
+            draw: true,
+            flip: true,
+        }
     },
     {
         protocol: "Unity",
         value: 1,
-        top: "",
-        middle: "",
-        bottom: "",
-        keywords: {}
+        top: "Start: If this card is covered, you may shift this card.",
+        middle: "If there are 5 or more Unity cards in the field, flip the Unity protocol to the compiled side and delete all cards in that line.",
+        bottom: "Unity cards may be played face-up in this line.",
+        keywords: {
+            flip: true,
+            play: true,
+            shift: true,
+        }
     },
     {
         protocol: "Unity",
         value: 2,
         top: "",
-        middle: "",
+        middle: "Draw cards equal to the number of Unity cards in the field.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            draw: true,
+        }
     },
     {
         protocol: "Unity",
         value: 3,
         top: "",
-        middle: "",
+        middle: "If there is another Unity card in the field, you may flip 1 face-up card.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            flip: true,
+        }
     },
     {
         protocol: "Unity",
         value: 4,
-        top: "",
+        top: "End: If your hand is empty, reveal your deck, draw all Unity cards from it, and shuffle your deck.",
         middle: "",
         bottom: "",
-        keywords: {}
+        keywords: {
+            draw: true,
+            reveal: true,
+        }
     },
     {
         protocol: "Unity",
         value: 5,
         top: "",
-        middle: "",
+        middle: "Discard 1 card.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            discard: true,
+        }
     },
 ]
 

--- a/script.js
+++ b/script.js
@@ -674,7 +674,7 @@ let cards = [
         protocol: "Plague",
         value: 2,
         top: "",
-        middle: "Dicard 1 or more cards. Your opponent discards the amount of cards discarded plus 1.",
+        middle: "Discard 1 or more cards. Your opponent discards the amount of cards discarded plus 1.",
         bottom: "",
         keywords: {
             discard: true,
@@ -894,7 +894,7 @@ let cards = [
         protocol: "Spirit",
         value: 4,
         top: "",
-        middle: "Swap the positions of 2 of your protocols",
+        middle: "Swap the positions of 2 of your protocols.",
         bottom: "",
         keywords: {
             swap: true,
@@ -1048,7 +1048,7 @@ let cards = [
         value: 1,
         top: "<div><span class='emphasis'>Start:</span> Reveal the top card of your deck. You may discard the top card of your deck.</div>",
         middle: "Your opponent reveals their hand.",
-        bottom: "When this card would be covered: First, draw 3 cards.",
+        bottom: "<div><span class='emphasis'>When this card would be covered:</span> First, draw 3 cards.</div>",
         keywords: {
             discard: true,
             draw: true,
@@ -1111,7 +1111,7 @@ let cards = [
         value: 1,
         top: "",
         middle: "Return 1 card.",
-        bottom: "When a card would be returned to your opponent's hard: Put that card on top of their deck face-down instead.",
+        bottom: "When a card would be returned to your opponent's hand: Put that card on top of their deck face-down instead.",
         keywords: {
             return: true,
         }
@@ -1173,7 +1173,7 @@ let cards = [
         protocol: "Courage",
         value: 1,
         top: "",
-        middle: "Delete 1 of your opponent's card in a line where they have a higher total value than you do.",
+        middle: "Delete 1 of your opponent's cards in a line where they have a higher total value than you do.",
         bottom: "",
         keywords: {
             delete: true,
@@ -1842,7 +1842,7 @@ let cards = [
         value: 0,
         top: "",
         middle: "If there is another Unity card in the field, either flip 1 card or draw 1 card.",
-        bottom: "When this card would be covered by a Unity card: First, either flip 1 card or draw 1 card.",
+        bottom: "<div><span class='emphasis'>When this card would be covered by a Unity card:</span> First, either flip 1 card or draw 1 card.</div>",
         keywords: {
             draw: true,
             flip: true,

--- a/script.js
+++ b/script.js
@@ -222,7 +222,7 @@ let cards = [
         value: 3,
         top: "",
         middle: "",
-        bottom: "<div><span class='empahsis'>End:</span> You may discard 1 card. If you do, flip 1 card.</div>",
+        bottom: "<div><span class='emphasis'>End:</span> You may discard 1 card. If you do, flip 1 card.</div>",
         keywords: {
             discard: true,
             flip: true,
@@ -980,7 +980,7 @@ let cards = [
         value: 0,
         top: "",
         middle: "In each line, flip 1 covered card.",
-        bottom: "Start: Draw the top card of your opponent's deck. Your opponent draws the top card of your deck.",
+        bottom: "<div><span class='emphasis'>Start:</span> Draw the top card of your opponent's deck. Your opponent draws the top card of your deck.</div>",
         keywords: {
             draw: true,
             flip: true,
@@ -1019,7 +1019,7 @@ let cards = [
         value: 4,
         top: "",
         middle: "",
-        bottom: "End: Discard your hand. Draw that many cards.",
+        bottom: "<div><span class='emphasis'>End:</span> Discard your hand. Draw that many cards.</div>",
         keywords: {
             discard: true,
             draw: true,
@@ -1046,10 +1046,11 @@ let cards = [
     {
         protocol: "Clarity",
         value: 1,
-        top: "Start: Reveal the top card of your deck. You may discard the top card of your deck.",
+        top: "<div><span class='emphasis'>Start:</span> Reveal the top card of your deck. You may discard the top card of your deck.</div>",
         middle: "Your opponent reveals their hand.",
         bottom: "When this card would be covered: First, draw 3 cards.",
         keywords: {
+            discard: true,
             draw: true,
             reveal: true,
         }
@@ -1062,6 +1063,7 @@ let cards = [
         bottom: "",
         keywords: {
             draw: true,
+            play: true,
             reveal: true,
         }
     },
@@ -1097,7 +1099,7 @@ let cards = [
     {
         protocol: "Corruption",
         value: 0,
-        top: "Start: Flip 1 other face-up covered or uncovered card in this stack.",
+        top: "<div><span class='emphasis'>Start:</span> Flip 1 other face-up covered or uncovered card in this stack.</div>",
         middle: "",
         bottom: "This card may be played on either player's side without matching protocols.",
         keywords: {
@@ -1117,7 +1119,7 @@ let cards = [
     {
         protocol: "Corruption",
         value: 2,
-        top: "After you discard cards: Your opponent discards 1 card.",
+        top: "<div><span class='emphasis'>After you discard cards:</span> Your opponent discards 1 card.</div>",
         middle: "Draw 1 card. Discard 1 card.",
         bottom: "",
         keywords: {
@@ -1148,7 +1150,7 @@ let cards = [
     {
         protocol: "Corruption",
         value: 6,
-        top: "End: Either discard 1 card or delete this card.",
+        top: "<div><span class='emphasis'>End:</span> Either discard 1 card or delete this card.</div>",
         middle: "",
         bottom: "",
         keywords: {
@@ -1159,9 +1161,9 @@ let cards = [
     {
         protocol: "Courage",
         value: 0,
-        top: "Start: If you have no cards in hand, draw 1 card.",
+        top: "<div><span class='emphasis'>Start:</span> If you have no cards in hand, draw 1 card.</div>",
         middle: "Draw 1 card.",
-        bottom: "End: You may discard 1 card. If you do, your opponent discards 1 card.",
+        bottom: "<div><span class='emphasis'>End:</span> You may discard 1 card. If you do, your opponent discards 1 card.</div>",
         keywords: {
             draw: true,
             discard: true,
@@ -1182,7 +1184,7 @@ let cards = [
         value: 2,
         top: "",
         middle: "Draw 1 card.",
-        bottom: "End: If your opponent has a higher total value than you do in this line, draw 1 card.",
+        bottom: "<div><span class='emphasis'>End:</span> If your opponent has a higher total value than you do in this line, draw 1 card.</div>",
         keywords: {
             draw: true,
         }
@@ -1192,7 +1194,7 @@ let cards = [
         value: 3,
         top: "",
         middle: "",
-        bottom: "End: You may shift this card to the line where your opponent has their highest total value.",
+        bottom: "<div><span class='emphasis'>End:</span> You may shift this card to the line where your opponent has their highest total value.</div>",
         keywords: {
             shift: true,
         }
@@ -1210,7 +1212,7 @@ let cards = [
     {
         protocol: "Courage",
         value: 6,
-        top: "End: If your opponent has a higher value in this line than you do, flip this card.",
+        top: "<div><span class='emphasis'>End:</span> If your opponent has a higher value in this line than you do, flip this card.</div>",
         middle: "",
         bottom: "",
         keywords: {
@@ -1284,7 +1286,7 @@ let cards = [
         value: 1,
         top: "",
         middle: "You may shift this card.",
-        bottom: "After your opponent plays a card in this line: Your opponent discards 1 card.",
+        bottom: "<div><span class='emphasis'>After your opponent plays a card in this line:</span> Your opponent discards 1 card.</div>",
         keywords: {
             discard: true,
             shift: true,
@@ -1303,7 +1305,7 @@ let cards = [
     {
         protocol: "Ice",
         value: 3,
-        top: "End: If this card is covered, you may shift it.",
+        top: "<div><span class='emphasis'>End:</span> If this card is covered, you may shift it.</div>",
         middle: "",
         bottom: "",
         keywords: {
@@ -1348,6 +1350,7 @@ let cards = [
         bottom: "",
         keywords: {
             draw: true,
+            play: true,
             reveal: true,
         }
     },
@@ -1418,7 +1421,7 @@ let cards = [
         value: 1,
         top: "",
         middle: "",
-        bottom: "End: You may resolve the middle command of 1 of your opponent's cards as if it were on this card.",
+        bottom: "<div><span class='emphasis'>End:</span> You may resolve the middle command of 1 of your opponent's cards as if it were on this card.</div>",
         keywords: {}
     },
     {
@@ -1446,7 +1449,7 @@ let cards = [
         value: 4,
         top: "",
         middle: "",
-        bottom: "After your opponent draws cards: Draw 1 card.",
+        bottom: "<div><span class='emphasis'>After your opponent draws cards:</span> Draw 1 card.</div>",
         keywords: {
             draw: true,
         }
@@ -1466,7 +1469,7 @@ let cards = [
         value: 1,
         top: "",
         middle: "Both players discard their hand.",
-        bottom: "End: If your hand is empty, draw 1 card.",
+        bottom: "<div><span class='emphasis'>End:</span> If your hand is empty, draw 1 card.</div>",
         keywords: {
             discard: true,
             draw: true,
@@ -1499,7 +1502,7 @@ let cards = [
         value: 4,
         top: "",
         middle: "",
-        bottom: "After you discard cards during your opponent's turn: Draw 1 card.",
+        bottom: "<div><span class='emphasis'>After you discard cards during your opponent's turn:</span> Draw 1 card.</div>",
         keywords: {
             discard: true,
             draw: true,
@@ -1608,7 +1611,7 @@ let cards = [
     {
         protocol: "Time",
         value: 2,
-        top: "After you shuffle your deck: Draw 1 card and you may shift this card.",
+        top: "<div><span class='emphasis'>After you shuffle your deck:</span> Draw 1 card and you may shift this card.</div>",
         middle: "If there are any cards in your trash, you may shuffle your trash into your deck.",
         bottom: "",
         keywords: {
@@ -1651,9 +1654,9 @@ let cards = [
     {
         protocol: "War",
         value: 0,
-        top: "After you refresh: You may flip this card.",
+        top: "<div><span class='emphasis'>After you refresh:</span> You may flip this card.</div>",
         middle: "",
-        bottom: "After your opponent draws cards: You may delete 1 card.",
+        bottom: "<div><span class='emphasis'>After your opponent draws cards:</span> You may delete 1 card.</div>",
         keywords: {
             delete: true,
             draw: true,
@@ -1665,9 +1668,10 @@ let cards = [
         value: 1,
         top: "",
         middle: "",
-        bottom: "After your opponent refreshes: Discard any number of cards. Refresh.",
+        bottom: "<div><span class='emphasis'>After your opponent refreshes:</span> Discard any number of cards. Refresh.</div>",
         keywords: {
             discard: true,
+            refresh: true,
         }
     },
     {
@@ -1675,7 +1679,7 @@ let cards = [
         value: 2,
         top: "",
         middle: "Flip 1 card.",
-        bottom: "After your opponent compiles: Your opponent discards their hand.",
+        bottom: "<div><span class='emphasis'>After your opponent compiles:</span> Your opponent discards their hand.</div>",
         keywords: {
             discard: true,
             flip: true,
@@ -1686,7 +1690,7 @@ let cards = [
         value: 3,
         top: "",
         middle: "Draw 1 card.",
-        bottom: "After your opponent discards cards: You may play 1 card face-down.",
+        bottom: "<div><span class='emphasis'>After your opponent discards cards:</span> You may play 1 card face-down.</div>",
         keywords: {
             discard: true,
             draw: true,
@@ -1718,7 +1722,7 @@ let cards = [
         value: 0,
         top: "",
         middle: "If there are 6 different protocols on cards in the field, flip the Diversity protocol to the compiled side.",
-        bottom: "End: You may play 1 non-Diversity card in this line.",
+        bottom: "<div><span class='emphasis'>End:</span> You may play 1 non-Diversity card in this line.</div>",
         keywords: {
             flip: true,
             play: true,
@@ -1766,7 +1770,7 @@ let cards = [
     {
         protocol: "Diversity",
         value: 6,
-        top: "End: If there are not at least 4 different protocols on cards in the field, delete this card.",
+        top: "<div><span class='emphasis'>End:</span> If there are not at least 4 different protocols on cards in the field, delete this card.</div>",
         middle: "",
         bottom: "",
         keywords: {
@@ -1786,10 +1790,11 @@ let cards = [
         value: 1,
         top: "",
         middle: "Discard 1 card. Refresh.",
-        bottom: "After a player refreshes: Draw the top card of your opponent's deck. Discard 1 card into their trash.",
+        bottom: "<div><span class='emphasis'>After a player refreshes:</span> Draw the top card of your opponent's deck. Discard 1 card into their trash.</div>",
         keywords: {
             discard: true,
             draw: true,
+            refresh: true,
         }
     },
     {
@@ -1797,7 +1802,7 @@ let cards = [
         value: 2,
         top: "",
         middle: "",
-        bottom: "End: Play the top card of your opponent's deck face-down in this stack.",
+        bottom: "<div><span class='emphasis'>End:</span> Play the top card of your opponent's deck face-down in this stack.</div>",
         keywords: {
             play: true,
         }
@@ -1827,7 +1832,7 @@ let cards = [
         value: 6,
         top: "",
         middle: "",
-        bottom: "End: Play the top card of your deck face-down on your opponent's side.",
+        bottom: "<div><span class='emphasis'>End:</span> Play the top card of your deck face-down on your opponent's side.</div>",
         keywords: {
             play: true,
         }
@@ -1846,10 +1851,11 @@ let cards = [
     {
         protocol: "Unity",
         value: 1,
-        top: "Start: If this card is covered, you may shift this card.",
+        top: "<div><span class='emphasis'>Start:</span> If this card is covered, you may shift this card.</div>",
         middle: "If there are 5 or more Unity cards in the field, flip the Unity protocol to the compiled side and delete all cards in that line.",
         bottom: "Unity cards may be played face-up in this line.",
         keywords: {
+            delete: true,
             flip: true,
             play: true,
             shift: true,
@@ -1878,7 +1884,7 @@ let cards = [
     {
         protocol: "Unity",
         value: 4,
-        top: "End: If your hand is empty, reveal your deck, draw all Unity cards from it, and shuffle your deck.",
+        top: "<div><span class='emphasis'>End:</span> If your hand is empty, reveal your deck, draw all Unity cards from it, and shuffle your deck.</div>",
         middle: "",
         bottom: "",
         keywords: {

--- a/script.js
+++ b/script.js
@@ -127,7 +127,7 @@ let cards = [
         middle: "Delete 1 card from each other line.",
         bottom: "",
         clarifications: [
-            "When Death 0's middle command triggers, the owner notes the lines that need to be acted in. Then, they choose which line to process, one at a time. For each line, they select an uncovered card to delete, processing the consequences of that delete before addressing the next line."
+            "When Death 0's middle command triggers, the owner notes the lines that need to be acted in. Then, they choose which line to process, one at a time. For each line, they select an uncovered card to delete, processing the consequences of that delete before addressing the next line.",
         ],
         keywords: {
             delete: true,
@@ -277,6 +277,9 @@ let cards = [
         top: "",
         middle: "Flip 1 card. Shift that card to this line.",
         bottom: "",
+        clarifications: [
+            "Gravity 2 will still shift the flipped card if it's covered. \u201cThat card\u201d references a specific card that supersedes the covered manipulation rule.",
+        ],
         keywords: {
             flip: true,
             shift: true,
@@ -288,9 +291,6 @@ let cards = [
         top: "",
         middle: "Shift 1 face-down card to this line.",
         bottom: "",
-        clarifications: [
-            "Gravity 2 will still shift the flipped card if it’s covered. “That card” references a specific card that supersedes the covered manipulation rule."
-        ],
         keywords: {
             shift: true,
         }
@@ -345,7 +345,7 @@ let cards = [
         bottom: "",
         clarifications: [
             "Multiple cards can be tied for the highest value. The player would choose one of the tied cards.",
-            "If Hate 2 is the highest value card you own it deletes itself as a result of the first clause. Thus, the second clause no longer exists and does not trigger."
+            "If Hate 2 is the highest value card you own it deletes itself as a result of the first clause. Thus, the second clause no longer exists and does not trigger.",
         ],
         keywords: {
             delete: true,
@@ -389,7 +389,7 @@ let cards = [
         bottom: "",
         clarifications: [
             "When Life 0's middle command triggers, the owner notes the lines that need to be acted in. Then, they choose which line to process, one at a time. For each line, they play the top card of their deck face-down, processing the consequences of that card play before addressing the next line. If Life 0 gets covered during this process, its middle command stops.",
-            "Playing cards from the top of a deck does not force a shuffle if that deck is empty."
+            "Playing cards from the top of a deck does not force a shuffle if that deck is empty.",
         ],
         keywords: {
             delete: true,
@@ -456,10 +456,10 @@ let cards = [
         middle: "Flip 1 card. Draw cards equal to that card's value.",
         bottom: "",
         clarifications: [
-            "The middle command reads ”Flip 1 card. Draw cards equal to that card’s value.” When played, the card owner chooses one uncovered card, flips that card, and then resolves any triggered text. Then, they draw cards equal to the current value of the chosen card (e.g. Light 0 selects Fire 5. First, Fire 5 is flipped face-down. Then, Light 0 checks the current value of the card, which is now 2. As a result, the active player draws 2 cards.)"
+            "The middle command reads ”Flip 1 card. Draw cards equal to that card’s value.” When played, the card owner chooses one uncovered card, flips that card, and then resolves any triggered text. Then, they draw cards equal to the current value of the chosen card (e.g. Light 0 selects Fire 5. First, Fire 5 is flipped face-down. Then, Light 0 checks the current value of the card, which is now 2. As a result, the active player draws 2 cards.)",
         ],
         rulings: [
-            "If the chosen card is removed from play, it is still referred to directly by the ”that card” text on Light 0. (e.g. Light 0 selects Metal 6. First, Metal 6's top command triggers: because it is about to be flipped, it deletes itself. Then, Light 0 checks the value of Metal 6, and, if it’s in the trash, its current value is 6 since all cards in the trash are face-up. The active player draws 6 cards. If the Metal 6 is private information (i.e. it was shuffled into your deck) it has a value of 2.)"
+            "If the chosen card is removed from play, it is still referred to directly by the ”that card” text on Light 0. (e.g. Light 0 selects Metal 6. First, Metal 6's top command triggers: because it is about to be flipped, it deletes itself. Then, Light 0 checks the value of Metal 6, and, if it’s in the trash, its current value is 6 since all cards in the trash are face-up. The active player draws 6 cards. If the Metal 6 is private information (i.e. it was shuffled into your deck) it has a value of 2.)",
         ],
         keywords: {
             draw: true,
@@ -496,7 +496,7 @@ let cards = [
         middle: "Shift all face-down cards in this line to another line.",
         bottom: "",
         clarifications: [
-            "The face-down cards shifted by Light 3 maintain the same relative positioning in their stacks and are all moved to the same line."
+            "The face-down cards shifted by Light 3 maintain the same relative positioning in their stacks and are all moved to the same line.",
         ],
         keywords: {
             shift: true,
@@ -604,7 +604,7 @@ let cards = [
         middle: "Draw 2 cards. Your opponent cannot compile on their next turn.",
         bottom: "",
         clarifications: [
-            "Metal 1 prevents your opponent from taking the compile action on their next turn, provided the text is visible. Since a player gets 1 action on their turn (compile, play, or refresh), they must either play or refresh on their next turn since they cannot compile."
+            "Metal 1 prevents your opponent from taking the compile action on their next turn, provided the text is visible. Since a player gets 1 action on their turn (compile, play, or refresh), they must either play or refresh on their next turn since they cannot compile.",
         ],
         keywords: {
             compile: true,
@@ -649,7 +649,7 @@ let cards = [
         bottom: "",
         clarifications: [
             "When Metal 6 deletes itself because of its top command, if it is covering a card with text that would trigger, that text triggers before the committed card enters the field.",
-            "When Metal 6 deletes itself as a result of being flipped, the “flip” command is used up and cannot be used on another card, nor can it be used on Metal 6 in the trash, as cards in the trash can’t be flipped."
+            "When Metal 6 deletes itself as a result of being flipped, the “flip” command is used up and cannot be used on another card, nor can it be used on Metal 6 in the trash, as cards in the trash can’t be flipped.",
         ],
         keywords: {
             delete: true,
@@ -694,7 +694,7 @@ let cards = [
         bottom: "",
         clarifications: [
             "The middle command reads “Flip each other face-up card.” This only affects uncovered cards, since it does not say “all”.",
-            "When Plague 3's middle command triggers, the owner notes each uncovered face-up card. Then, they choose which card to process, one at a time. For each card, they flip it and process any consequences before addressing the next card"
+            "When Plague 3's middle command triggers, the owner notes each uncovered face-up card. Then, they choose which card to process, one at a time. For each card, they flip it and process any consequences before addressing the next card",
         ],
         keywords: {
             flip: true,
@@ -813,7 +813,7 @@ let cards = [
         middle: "",
         bottom: "",
         clarifications: [
-            "When compiling, all cards in the line are deleted at the same time. When Speed 2 would be deleted this way, instead, you shift it to another line, preventing the delete of Speed 2 only, and not altering the compile."
+            "When compiling, all cards in the line are deleted at the same time. When Speed 2 would be deleted this way, instead, you shift it to another line, preventing the delete of Speed 2 only, and not altering the compile.",
         ],
         keywords: {
             compile: true,
@@ -858,7 +858,7 @@ let cards = [
         middle: "Refresh. Draw 1 card.",
         bottom: "Skip your check cache phase.",
         clarifications: [
-            "When you refresh as instructed, it is a normal refresh action, including spending the control component, if applicable."
+            "When you refresh as instructed, it is a normal refresh action, including spending the control component, if applicable.",
         ],
         keywords: {
             draw: true,
@@ -935,7 +935,7 @@ let cards = [
         bottom: "",
         clarifications: [
             "When Water 1's middle command triggers, the owner notes the lines that need to be acted in. Then, they choose which line to process, one at a time. For each line, they play the top card of their deck face-down, processing the consequences of that card play before addressing the next line.",
-            "Playing cards from the top of a deck does not force a shuffle if that deck is empty."
+            "Playing cards from the top of a deck does not force a shuffle if that deck is empty.",
         ],
         keywords: {
             play: true,
@@ -987,8 +987,11 @@ let cards = [
         protocol: "Chaos",
         value: 0,
         top: "",
-        middle: "In each line, flip 1 covered card.",
+        middle: "Flip 1 covered card in each line.",
         bottom: "<div><span class='emphasis'>Start:</span> Draw the top card of your opponent's deck. Your opponent draws the top card of your deck.</div>",
+        clarifications: [
+            "When Chaos 0's middle command triggers, the owner notes each line that needs to be acted in. Then, they choose which line to process, one at a time. For each line, they select a covered card to flip, processing the consequences of that flip before addressing the next line. Covered cards never activate their middle command when flipped.",
+        ],
         keywords: {
             draw: true,
             flip: true,
@@ -1001,6 +1004,9 @@ let cards = [
         top: "",
         middle: "Rearrange your protocols. Rearrange your opponent's protocols.",
         bottom: "",
+        clarifications: [
+            "You must make a change to the protocols of both players.",
+        ],
         keywords: {
             rearrange: true,
         }
@@ -1168,6 +1174,9 @@ let cards = [
         top: "<div><span class='emphasis'>End:</span> Either discard 1 card or delete this card.</div>",
         middle: "",
         bottom: "",
+        clarifications: [
+            "This will trigger the middle command of the card it was covering if it deletes itself at the end of turn.",
+        ],
         keywords: {
             delete: true,
             discard: true,
@@ -1210,6 +1219,9 @@ let cards = [
         top: "",
         middle: "",
         bottom: "<div><span class='emphasis'>End:</span> You may shift this card to the line where your opponent has their highest total value.</div>",
+        clarifications: [
+            "Multiple lines can be tied for “highest total value”. In this case, the player chooses.",
+        ],
         keywords: {
             shift: true,
         }
@@ -1353,6 +1365,9 @@ let cards = [
         top: "If you have any cards in your hand, you cannot draw cards.",
         middle: "",
         bottom: "",
+        clarifications: [
+            "Cards are drawn in a batch. Refreshing with 0 cards in hand will draw you 5 cards.",
+        ],
         keywords: {
             draw: true,
         }
@@ -1363,6 +1378,9 @@ let cards = [
         top: "",
         middle: "State a number. Draw 3 cards. Reveal 1 card drawn with the face-up value of your stated number. You may play it.",
         bottom: "",
+        clarifications: [
+            "The played card must be one that you drew with Luck 0. You can play the card face-up or face-down.",
+        ],
         keywords: {
             draw: true,
             play: true,
@@ -1373,8 +1391,11 @@ let cards = [
         protocol: "Luck",
         value: 1,
         top: "",
-        middle: "Play the top card of your deck face-down. Flip that card, ignoring middle commands.",
+        middle: "Play the top card of your deck face-down. Flip that card, ignoring its middle command.",
         bottom: "",
+        clarifications: [
+            "The middle command is only ignored for the flip.",
+        ],
         keywords: {
             flip: true,
             play: true,
@@ -1397,7 +1418,7 @@ let cards = [
         protocol: "Luck",
         value: 3,
         top: "",
-        middle: "State a protocol. Discard the top card of your opponent's deck. If the discarded card matches the stated protocol, delete 1 card.",
+        middle: "State a protocol. Discard the top card of your opponent's deck. If the discarded card matched the stated protocol, delete 1 card.",
         bottom: "",
         keywords: {
             delete: true,
@@ -1441,6 +1462,9 @@ let cards = [
         top: "",
         middle: "",
         bottom: "<div><span class='emphasis'>End:</span> You may resolve the middle command of 1 of your opponent's cards as if it were on this card.</div>",
+        clarifications: [
+            "Mirror 1’s bottom text is blocked by Fear 0 because the text is treated “as if it were on this card” but there’s no text to copy because Fear 0 says the “cards do not have middle commands”.",
+        ],
         keywords: {}
     },
     {
@@ -1449,6 +1473,9 @@ let cards = [
         top: "",
         middle: "Swap all of your cards in one of your stacks with another one of your stacks.",
         bottom: "",
+        clarifications: [
+            "The swapped cards keep the same relative positions. A stack must have at least 1 card in it to swap.",
+        ],
         keywords: {
             swap: true,
         }
@@ -1459,6 +1486,9 @@ let cards = [
         top: "",
         middle: "Flip 1 of your cards. Flip 1 of your opponent's cards in the same line.",
         bottom: "",
+        clarifications: [
+            "If Mirror 3 flips itself first, the second flip doesn’t happen.",
+        ],
         keywords: {
             flip: true,
         }
@@ -1489,6 +1519,9 @@ let cards = [
         top: "",
         middle: "Both players discard their hand.",
         bottom: "<div><span class='emphasis'>End:</span> If your hand is empty, draw 1 card.</div>",
+        clarifications: [
+            "The owner decides which player discards their hand first.",
+        ],
         keywords: {
             discard: true,
             draw: true,
@@ -1553,6 +1586,9 @@ let cards = [
         top: "",
         middle: "Play the top card of your deck face-down in each line with a face-down card.",
         bottom: "",
+        clarifications: [
+            "Both Smoke 0 and 3 count your opponent’s face-down cards.",
+        ],
         keywords: {
             play: true,
             topDeck: true,
@@ -1583,6 +1619,9 @@ let cards = [
         top: "",
         middle: "Play 1 card face-down in a line with a face-down card.",
         bottom: "",
+        clarifications: [
+            "Both Smoke 0 and 3 count your opponent’s face-down cards.",
+        ],
         keywords: {
             play: true,
         }
@@ -1633,7 +1672,7 @@ let cards = [
     {
         protocol: "Time",
         value: 2,
-        top: "<div><span class='emphasis'>After you shuffle your deck:</span> Draw 1 card and you may shift this card.</div>",
+        top: "<div><span class='emphasis'>After you shuffle your deck:</span> Draw 1 card. Then, you may shift this card.</div>",
         middle: "If there are any cards in your trash, you may shuffle your trash into your deck.",
         bottom: "",
         keywords: {

--- a/script.js
+++ b/script.js
@@ -126,6 +126,9 @@ let cards = [
         top: "",
         middle: "Delete 1 card from each other line.",
         bottom: "",
+        clarifications: [
+            "When Death 0's middle command triggers, the owner notes the lines that need to be acted in. Then, they choose which line to process, one at a time. For each line, they select an uncovered card to delete, processing the consequences of that delete before addressing the next line."
+        ],
         keywords: {
             delete: true,
         }
@@ -133,7 +136,7 @@ let cards = [
     {
         protocol: "Death",
         value: 1,
-        top: "<div><span class='emphasis'>Start:</span> You may draw 1 card. If you do, delete 1 other card, then delete this card.</div>",
+        top: "<div><span class='emphasis'>Start:</span> You may draw 1 card. If you do, delete 1 other card. Then, delete this card.</div>",
         middle: "",
         bottom: "",
         keywords: {
@@ -186,7 +189,7 @@ let cards = [
         value: 0,
         top: "",
         middle: "Flip 1 other card. Draw 2 cards.",
-        bottom: "<div><span class='emphasis'>When this card would be covered:</span> First, draw 1 card and flip 1 other card.</div>",
+        bottom: "<div><span class='emphasis'>When this card would be covered:</span> First, draw 1 card. Then, flip 1 other card.</div>",
         keywords: {
             draw: true,
             flip: true,
@@ -284,6 +287,9 @@ let cards = [
         top: "",
         middle: "Shift 1 face-down card to this line.",
         bottom: "",
+        clarifications: [
+            "Gravity 2 will still shift the flipped card if it’s covered. “That card” references a specific card that supersedes the covered manipulation rule."
+        ],
         keywords: {
             shift: true,
         }
@@ -333,8 +339,12 @@ let cards = [
         protocol: "Hate",
         value: 2,
         top: "",
-        middle: "Delete your highest value card. Delete your opponent's highest value card.",
+        middle: "Delete your highest value uncovered card. Delete your opponent's highest value uncovered card.",
         bottom: "",
+        clarifications: [
+            "Multiple cards can be tied for the highest value. The player would choose one of the tied cards.",
+            "If Hate 2 is the highest value card you own it deletes itself as a result of the first clause. Thus, the second clause no longer exists and does not trigger."
+        ],
         keywords: {
             delete: true,
         }
@@ -372,9 +382,13 @@ let cards = [
     {
         protocol: "Life",
         value: 0,
-        top: "",
+        top: "<div><span class='emphasis'>End:</span> If this card is covered, delete this card.</div>",
         middle: "Play the top card of your deck face-down in each line where you have a card.",
-        bottom: "<div><span class='emphasis'>When this card would be covered:</span> First, delete this card.</div>",
+        bottom: "",
+        clarifications: [
+            "When Life 0's middle command triggers, the owner notes the lines that need to be acted in. Then, they choose which line to process, one at a time. For each line, they play the top card of their deck face-down, processing the consequences of that card play before addressing the next line. If Life 0 gets covered during this process, its middle command stops.",
+            "Playing cards from the top of a deck does not force a shuffle if that deck is empty."
+        ],
         keywords: {
             delete: true,
             play: true,
@@ -437,6 +451,12 @@ let cards = [
         top: "",
         middle: "Flip 1 card. Draw cards equal to that card's value.",
         bottom: "",
+        clarifications: [
+            "The middle command reads ”Flip 1 card. Draw cards equal to that card’s value.” When played, the card owner chooses one uncovered card, flips that card, and then resolves any triggered text. Then, they draw cards equal to the current value of the chosen card (e.g. Light 0 selects Fire 5. First, Fire 5 is flipped face-down. Then, Light 0 checks the current value of the card, which is now 2. As a result, the active player draws 2 cards.)"
+        ],
+        rulings: [
+            "If the chosen card is removed from play, it is still referred to directly by the ”that card” text on Light 0. (e.g. Light 0 selects Metal 6. First, Metal 6's top command triggers: because it is about to be flipped, it deletes itself. Then, Light 0 checks the value of Metal 6, and, if it’s in the trash, its current value is 6 since all cards in the trash are face-up. The active player draws 6 cards. If the Metal 6 is private information (i.e. it was shuffled into your deck) it has a value of 2.)"
+        ],
         keywords: {
             draw: true,
             flip: true,
@@ -471,6 +491,9 @@ let cards = [
         top: "",
         middle: "Shift all face-down cards in this line to another line.",
         bottom: "",
+        clarifications: [
+            "The face-down cards shifted by Light 3 maintain the same relative positioning in their stacks and are all moved to the same line."
+        ],
         keywords: {
             shift: true,
         }
@@ -573,8 +596,11 @@ let cards = [
         protocol: "Metal",
         value: 1,
         top: "",
-        middle: "Draw 2 cards. Your opponent cannot compile next turn.",
+        middle: "Draw 2 cards. Your opponent cannot compile on their next turn.",
         bottom: "",
+        clarifications: [
+            "Metal 1 prevents your opponent from taking the compile action on their next turn, provided the text is visible. Since a player gets 1 action on their turn (compile, play, or refresh), they must either play or refresh on their next turn since they cannot compile."
+        ],
         keywords: {
             draw: true,
         }
@@ -615,6 +641,10 @@ let cards = [
         top: "<div><span class='emphasis'>When this card would be covered or flipped:</span> First, delete this card.</div>",
         middle: "",
         bottom: "",
+        clarifications: [
+            "When Metal 6 deletes itself because of its top command, if it is covering a card with text that would trigger, that text triggers before the committed card enters the field.",
+            "When Metal 6 deletes itself as a result of being flipped, the “flip” command is used up and cannot be used on another card, nor can it be used on Metal 6 in the trash, as cards in the trash can’t be flipped."
+        ],
         keywords: {
             delete: true,
         }
@@ -654,8 +684,12 @@ let cards = [
         protocol: "Plague",
         value: 3,
         top: "",
-        middle: "Flip each other face-up card.",
+        middle: "Flip each other uncovered face-up card.",
         bottom: "",
+        clarifications: [
+            "The middle command reads “Flip each other face-up card.” This only affects uncovered cards, since it does not say “all”.",
+            "When Plague 3's middle command triggers, the owner notes each uncovered face-up card. Then, they choose which card to process, one at a time. For each card, they flip it and process any consequences before addressing the next card"
+        ],
         keywords: {
             flip: true,
         }
@@ -772,6 +806,9 @@ let cards = [
         top: "<div><span class='emphasis'>When this card would be deleted by compiling:</span> Shift this card, even if this card is covered.</div>",
         middle: "",
         bottom: "",
+        clarifications: [
+            "When compiling, all cards in the line are deleted at the same time. When Speed 2 would be deleted this way, instead, you shift it to another line, preventing the delete of Speed 2 only, and not altering the compile."
+        ],
         keywords: {
             shift: true,
         }
@@ -813,6 +850,9 @@ let cards = [
         top: "",
         middle: "Refresh. Draw 1 card.",
         bottom: "Skip your check cache phase.",
+        clarifications: [
+            "When you refresh as instructed, it is a normal refresh action, including spending the control component, if applicable."
+        ],
         keywords: {
             draw: true,
             refresh: true,
@@ -821,7 +861,7 @@ let cards = [
     {
         protocol: "Spirit",
         value: 1,
-        top: "You can play cards in any line.",
+        top: "When you play cards face-up, they may be played without matching protocols.",
         middle: "Draw 2 cards.",
         bottom: "<div><span class='emphasis'>Start:</span> Either discard 1 card or flip this card.</div>",
         keywords: {
@@ -886,6 +926,10 @@ let cards = [
         top: "",
         middle: "Play the top card of your deck face-down in each other line.",
         bottom: "",
+        clarifications: [
+            "When Water 1's middle command triggers, the owner notes the lines that need to be acted in. Then, they choose which line to process, one at a time. For each line, they play the top card of their deck face-down, processing the consequences of that card play before addressing the next line.",
+            "Playing cards from the top of a deck does not force a shuffle if that deck is empty."
+        ],
         keywords: {
             play: true,
         }

--- a/script.js
+++ b/script.js
@@ -257,6 +257,7 @@ let cards = [
         bottom: "",
         keywords: {
             play: true,
+            topDeck: true,
         }
     },
     {
@@ -312,6 +313,7 @@ let cards = [
         bottom: "",
         keywords: {
             play: true,
+            topDeck: true,
         }
     },
     {
@@ -392,6 +394,7 @@ let cards = [
         keywords: {
             delete: true,
             play: true,
+            topDeck: true,
         }
     },
     {
@@ -423,6 +426,7 @@ let cards = [
         bottom: "<div><span class='emphasis'>When this card would be covered:</span> First, play the top card of your deck face-down in another line.</div>",
         keywords: {
             play: true,
+            topDeck: true,
         }
     },
     {
@@ -527,6 +531,7 @@ let cards = [
         keywords: {
             draw: true,
             give: true,
+            topDeck: true,
         }
     },
     {
@@ -602,6 +607,7 @@ let cards = [
             "Metal 1 prevents your opponent from taking the compile action on their next turn, provided the text is visible. Since a player gets 1 action on their turn (compile, play, or refresh), they must either play or refresh on their next turn since they cannot compile."
         ],
         keywords: {
+            compile: true,
             draw: true,
         }
     },
@@ -810,6 +816,7 @@ let cards = [
             "When compiling, all cards in the line are deleted at the same time. When Speed 2 would be deleted this way, instead, you shift it to another line, preventing the delete of Speed 2 only, and not altering the compile."
         ],
         keywords: {
+            compile: true,
             shift: true,
         }
     },
@@ -932,6 +939,7 @@ let cards = [
         ],
         keywords: {
             play: true,
+            topDeck: true,
         }
     },
     {
@@ -984,6 +992,7 @@ let cards = [
         keywords: {
             draw: true,
             flip: true,
+            topDeck: true,
         }
     },
     {
@@ -1053,6 +1062,7 @@ let cards = [
             discard: true,
             draw: true,
             reveal: true,
+            topDeck: true,
         }
     },
     {
@@ -1065,6 +1075,7 @@ let cards = [
             draw: true,
             play: true,
             reveal: true,
+            shuffle: true,
         }
     },
     {
@@ -1076,6 +1087,7 @@ let cards = [
         keywords: {
             draw: true,
             reveal: true,
+            shuffle: true,
         }
     },
     {
@@ -1084,7 +1096,10 @@ let cards = [
         top: "",
         middle: "You may shuffle your trash into your deck.",
         bottom: "",
-        keywords: {}
+        keywords: {
+            shuffle: true,
+            trash: true,
+        }
     },
     {
         protocol: "Clarity",
@@ -1363,6 +1378,7 @@ let cards = [
         keywords: {
             flip: true,
             play: true,
+            topDeck: true,
         }
     },
     {
@@ -1374,6 +1390,7 @@ let cards = [
         keywords: {
             discard: true,
             draw: true,
+            topDeck: true,
         }
     },
     {
@@ -1385,6 +1402,7 @@ let cards = [
         keywords: {
             delete: true,
             discard: true,
+            topDeck: true,
         }
     },
     {
@@ -1396,6 +1414,7 @@ let cards = [
         keywords: {
             delete: true,
             discard: true,
+            topDeck: true,
         }
     },
     {
@@ -1536,6 +1555,7 @@ let cards = [
         bottom: "",
         keywords: {
             play: true,
+            topDeck: true,
         }
     },
     {
@@ -1595,6 +1615,8 @@ let cards = [
         bottom: "",
         keywords: {
             play: true,
+            shuffle: true,
+            trash: true,
         }
     },
     {
@@ -1617,6 +1639,8 @@ let cards = [
         keywords: {
             draw: true,
             shift: true,
+            shuffle: true,
+            trash: true,
         }
     },
     {
@@ -1628,6 +1652,7 @@ let cards = [
         keywords: {
             play: true,
             reveal: true,
+            trash: true,
         }
     },
     {
@@ -1681,6 +1706,7 @@ let cards = [
         middle: "Flip 1 card.",
         bottom: "<div><span class='emphasis'>After your opponent compiles:</span> Your opponent discards their hand.</div>",
         keywords: {
+            compile: true,
             discard: true,
             flip: true,
         }
@@ -1724,6 +1750,7 @@ let cards = [
         middle: "If there are 6 different protocols on cards in the field, flip the Diversity protocol to the compiled side.",
         bottom: "<div><span class='emphasis'>End:</span> You may play 1 non-Diversity card in this line.</div>",
         keywords: {
+            compile: true,
             flip: true,
             play: true,
         }
@@ -1795,6 +1822,8 @@ let cards = [
             discard: true,
             draw: true,
             refresh: true,
+            topDeck: true,
+            trash: true,
         }
     },
     {
@@ -1805,6 +1834,7 @@ let cards = [
         bottom: "<div><span class='emphasis'>End:</span> Play the top card of your opponent's deck face-down in this stack.</div>",
         keywords: {
             play: true,
+            topDeck: true,
         }
     },
     {
@@ -1815,6 +1845,7 @@ let cards = [
         bottom: "",
         keywords: {
             draw: true,
+            topDeck: true,
         }
     },
     {
@@ -1835,6 +1866,7 @@ let cards = [
         bottom: "<div><span class='emphasis'>End:</span> Play the top card of your deck face-down on your opponent's side.</div>",
         keywords: {
             play: true,
+            topDeck: true,
         }
     },
     {
@@ -1855,6 +1887,7 @@ let cards = [
         middle: "If there are 5 or more Unity cards in the field, flip the Unity protocol to the compiled side and delete all cards in that line.",
         bottom: "Unity cards may be played face-up in this line.",
         keywords: {
+            compile: true,
             delete: true,
             flip: true,
             play: true,
@@ -1890,6 +1923,7 @@ let cards = [
         keywords: {
             draw: true,
             reveal: true,
+            shuffle: true,
         }
     },
     {
@@ -2009,13 +2043,13 @@ function checkFilters() {
 
     let [zero, one, two, three, four, five, six] = checkValue();
 
-    let [deleteVar, discard, draw, flip, give, play, rearrange, returnVar, reveal, refresh, shift, swap, take] = checkKeywords();
+    let [compile, deleteVar, discard, draw, flip, give, play, rearrange, returnVar, reveal, refresh, shift, shuffle, swap, take, topDeck, trash] = checkKeywords();
 
     array = getProtocols(array);
 
     array = getValue(array, zero, one, two, three, four, five, six);
 
-    array = getKeywords(array, deleteVar, discard, draw, flip, give, play, rearrange, returnVar, reveal, refresh, shift, swap, take);
+    array = getKeywords(array, compile, deleteVar, discard, draw, flip, give, play, rearrange, returnVar, reveal, refresh, shift, shuffle, swap, take, topDeck, trash);
 
     displayCards(array);
 }
@@ -2034,6 +2068,7 @@ function checkValue() {
 };
 
 function checkKeywords() {
+    let compile = $('.js_compile').is(':checked');
     let deleteVar = $('.js_delete').is(':checked');
     let discard = $('.js_discard').is(':checked');
     let draw = $('.js_draw').is(':checked');
@@ -2045,10 +2080,13 @@ function checkKeywords() {
     let reveal = $('.js_reveal').is(':checked');
     let refresh = $('.js_refresh').is(':checked');
     let shift = $('.js_shift').is(':checked');
+    let shuffle = $('.js_shuffle').is(':checked');
     let swap = $('.js_swap').is(':checked');
     let take = $('.js_take').is(':checked');
+    let topDeck = $('.js_top-deck').is(':checked');
+    let trash = $('.js_trash').is(':checked');
 
-    return [deleteVar, discard, draw, flip, give, play, rearrange, returnVar, reveal, refresh, shift, swap, take];
+    return [compile, deleteVar, discard, draw, flip, give, play, rearrange, returnVar, reveal, refresh, shift, shuffle, swap, take, topDeck, trash];
 }
 
 function getProtocols(array) {
@@ -2085,7 +2123,10 @@ function getValue(array, zero, one, two, three, four, five, six) {
     return array;
 }
 
-function getKeywords(array, deleteVar, discard, draw, flip, give, play, rearrange, returnVar, reveal, refresh, shift, swap, take) {
+function getKeywords(array, compile, deleteVar, discard, draw, flip, give, play, rearrange, returnVar, reveal, refresh, shift, shuffle, swap, take, topDeck, trash) {
+    if (compile) {
+        array = array.filter(cards => cards.keywords.compile == true);
+    }
     if (deleteVar) {
         array = array.filter(cards => cards.keywords.delete == true);
     }
@@ -2119,11 +2160,20 @@ function getKeywords(array, deleteVar, discard, draw, flip, give, play, rearrang
     if (shift) {
         array = array.filter(cards => cards.keywords.shift == true);
     }
+    if (shuffle) {
+        array = array.filter(cards => cards.keywords.shuffle == true);
+    }
     if (swap) {
         array = array.filter(cards => cards.keywords.swap == true);
     }
     if (take) {
         array = array.filter(cards => cards.keywords.take == true);
+    }
+    if (topDeck) {
+        array = array.filter(cards => cards.keywords.topDeck == true);
+    }
+    if (trash) {
+        array = array.filter(cards => cards.keywords.trash == true);
     }
 
     return array;

--- a/script.js
+++ b/script.js
@@ -1135,6 +1135,7 @@ let cards = [
         bottom: "<div><span class='emphasis'>When a card would be returned to your opponent's hand:</span> Put that card on top of their deck face-down instead.</div>",
         keywords: {
             return: true,
+            topDeck: true,
         }
     },
     {

--- a/script.js
+++ b/script.js
@@ -1976,13 +1976,50 @@ let cards = [
             discard: true,
         }
     },
+    {
+        protocol: "Envy",
+        value: 1,
+        top: "",
+        middle: "If your opponent has control, you may flip 1 card.",
+        bottom: "<div><span class='emphasis'>Start:</span> If your opponent has control, gain control.</div>",
+        keywords: {
+            control: true,
+            flip: true,
+        }
+    },
+    {
+        protocol: "Lust",
+        value: 0,
+        top: "Each player's total value in this line is increased by 10.",
+        middle: "Gain control.",
+        bottom: "Your opponent can't compile if you have control.",
+        keywords: {
+            compile: true,
+            control: true,
+        }
+    },
+    {
+        protocol: "Pride",
+        value: 0,
+        top: "<div><span class='emphasis'>After you compile:</span> Refresh.</div>",
+        middle: "If you have control, shift 1 other card. Else, shift 1 of your cards.",
+        bottom: "",
+        keywords: {
+            compile: true,
+            control: true,
+            refresh: true,
+            shift: true,
+        }
+    },
 ]
 
 const programs = {
     "Main 1": ["Darkness", "Death", "Fire", "Gravity", "Life", "Light", "Metal", "Plague", "Psychic", "Speed", "Spirit", "Water"],
     "Aux 1": ["Apathy", "Hate", "Love"],
     "Main 2": ["Chaos", "Clarity", "Corruption", "Courage", "Fear", "Ice", "Luck", "Mirror", "Peace", "Smoke", "Time", "War"],
-    "Aux 2": ["Diversity", "Assimilation", "Unity"]
+    "Aux 2": ["Diversity", "Assimilation", "Unity"],
+    "Main 3": ["Ambush", "Envy", "Fulcrum", "Gluttony", "Greed", "Lust", "Momentum", "Nova", "Overwhelm", "Pride", "Sloth", "Wrath"],
+    "Aux 3": ["Flexible", "Inert", "Rigid"]
 };
 
 initialize();
@@ -2034,6 +2071,16 @@ $(document).on('click', '.js_collapse-program', function() {
     $(this).html($list.hasClass('filters__program-list--collapsed') ? '&#9654;' : '&#9660;');
 });
 
+$(document).on('click', '.js_expand-all-programs', function() {
+    $('.filters__program-list').removeClass('filters__program-list--collapsed');
+    $('.js_collapse-program').html('&#9660;');
+});
+
+$(document).on('click', '.js_collapse-all-programs', function() {
+    $('.filters__program-list').addClass('filters__program-list--collapsed');
+    $('.js_collapse-program').html('&#9654;');
+});
+
 $(document).on('click', '.js_select-all-program', function() {
     $(this).closest('.filters__program').find('.js_protocol').prop('checked', true);
     checkFilters();
@@ -2051,6 +2098,9 @@ function buildProtocolFilter() {
     Object.entries(programs).forEach(([programName, protocols]) => {
         const programId = programName.toLowerCase().replace(/\s+/g, '-');
         const listId = `program-list-${programId}`;
+        const collapsed = programName !== "Main 1";
+        const listClass = collapsed ? "filters__program-list filters__program-list--collapsed" : "filters__program-list";
+        const arrow = collapsed ? "&#9654;" : "&#9660;";
 
         const protocolItems = protocols.map(protocol => {
             const protocolLower = protocol.toLowerCase();
@@ -2064,14 +2114,14 @@ function buildProtocolFilter() {
         $list.append(`
             <li class="filters__program">
                 <div class="filters__program-header">
-                    <button class="filters__collapse-btn js_collapse-program" data-target="${listId}">&#9660;</button>
+                    <button class="filters__collapse-btn js_collapse-program" data-target="${listId}">${arrow}</button>
                     <span class="filters__program-name">${programName}</span>
                     <div class="filters__program-btns">
                         <button class="filters__btn filters__btn--sm js_select-all-program">Select All</button>
                         <button class="filters__btn filters__btn--sm js_remove-all-program">Remove All</button>
                     </div>
                 </div>
-                <ul class="filters__program-list" id="${listId}">
+                <ul class="${listClass}" id="${listId}">
                     ${protocolItems}
                 </ul>
             </li>`);
@@ -2083,13 +2133,13 @@ function checkFilters() {
 
     let [zero, one, two, three, four, five, six] = checkValue();
 
-    let [compile, deleteVar, discard, draw, flip, give, play, rearrange, returnVar, reveal, refresh, shift, shuffle, swap, take, topDeck, trash] = checkKeywords();
+    let [compile, control, deleteVar, discard, draw, flip, give, play, rearrange, returnVar, reveal, refresh, shift, shuffle, swap, take, topDeck, trash] = checkKeywords();
 
     array = getProtocols(array);
 
     array = getValue(array, zero, one, two, three, four, five, six);
 
-    array = getKeywords(array, compile, deleteVar, discard, draw, flip, give, play, rearrange, returnVar, reveal, refresh, shift, shuffle, swap, take, topDeck, trash);
+    array = getKeywords(array, compile, control, deleteVar, discard, draw, flip, give, play, rearrange, returnVar, reveal, refresh, shift, shuffle, swap, take, topDeck, trash);
 
     displayCards(array);
 }
@@ -2109,6 +2159,7 @@ function checkValue() {
 
 function checkKeywords() {
     let compile = $('.js_compile').is(':checked');
+    let control = $('.js_control').is(':checked');
     let deleteVar = $('.js_delete').is(':checked');
     let discard = $('.js_discard').is(':checked');
     let draw = $('.js_draw').is(':checked');
@@ -2126,7 +2177,7 @@ function checkKeywords() {
     let topDeck = $('.js_top-deck').is(':checked');
     let trash = $('.js_trash').is(':checked');
 
-    return [compile, deleteVar, discard, draw, flip, give, play, rearrange, returnVar, reveal, refresh, shift, shuffle, swap, take, topDeck, trash];
+    return [compile, control, deleteVar, discard, draw, flip, give, play, rearrange, returnVar, reveal, refresh, shift, shuffle, swap, take, topDeck, trash];
 }
 
 function getProtocols(array) {
@@ -2163,9 +2214,12 @@ function getValue(array, zero, one, two, three, four, five, six) {
     return array;
 }
 
-function getKeywords(array, compile, deleteVar, discard, draw, flip, give, play, rearrange, returnVar, reveal, refresh, shift, shuffle, swap, take, topDeck, trash) {
+function getKeywords(array, compile, control, deleteVar, discard, draw, flip, give, play, rearrange, returnVar, reveal, refresh, shift, shuffle, swap, take, topDeck, trash) {
     if (compile) {
         array = array.filter(cards => cards.keywords.compile == true);
+    }
+    if (control) {
+        array = array.filter(cards => cards.keywords.control == true);
     }
     if (deleteVar) {
         array = array.filter(cards => cards.keywords.delete == true);

--- a/script.js
+++ b/script.js
@@ -1988,6 +1988,17 @@ let cards = [
         }
     },
     {
+        protocol: "Greed",
+        value: 2,
+        top: "",
+        middle: "Your opponent discards 1 card.",
+        bottom: "<div><span class='emphasis'>Start:</span> You may return 1 of your cards.</div>",
+        keywords: {
+            discard: true,
+            return: true,
+        }
+    },
+    {
         protocol: "Lust",
         value: 0,
         top: "Each player's total value in this line is increased by 10.",
@@ -1996,6 +2007,18 @@ let cards = [
         keywords: {
             compile: true,
             control: true,
+        }
+    },
+    {
+        protocol: "Lust",
+        value: 4,
+        top: "",
+        middle: "Reveal your hand. Your opponent loses control.",
+        bottom: "<div><span class='emphasis'>After your opponent gains control:</span> Draw 1 card.</div>",
+        keywords: {
+            control: true,
+            draw: true,
+            reveal: true,
         }
     },
     {
@@ -2009,6 +2032,17 @@ let cards = [
             control: true,
             refresh: true,
             shift: true,
+        }
+    },
+    {
+        protocol: "Flexible",
+        value: 3,
+        top: "",
+        middle: "Shift 1 of your opponent's cards or swap 2 of your protocols.",
+        bottom: "",
+        keywords: {
+            shift: true,
+            swap: true,
         }
     },
 ]

--- a/style.css
+++ b/style.css
@@ -189,3 +189,64 @@
     cursor: pointer;
   }
 
+  /* Protocol program groups */
+
+  .js_protocol-list {
+    display: block;
+  }
+
+  .filters__program {
+    list-style-type: none;
+    margin-bottom: 0.75rem;
+  }
+
+  .filters__program-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.25rem;
+  }
+
+  .filters__program-name {
+    font-size: 16px;
+    font-weight: bold;
+    flex: 1;
+  }
+
+  .filters__program-btns {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .filters__program-list {
+    list-style-type: none;
+    padding: 0 0 0 1rem;
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    grid-gap: 0.5rem;
+    margin: 0.25rem 0 0.5rem;
+  }
+
+  .filters__program-list--collapsed {
+    display: none;
+  }
+
+  .filters__collapse-btn {
+    background: none;
+    border: 1px solid black;
+    cursor: pointer;
+    padding: 2px 6px;
+    font-size: 12px;
+    line-height: 1;
+  }
+  .filters__collapse-btn:hover {
+    background-color: black;
+    color: white;
+  }
+
+  .filters__btn--sm {
+    margin: 0.25rem;
+    padding: 0.25rem 0.5rem;
+    font-size: 14px;
+  }
+

--- a/style.css
+++ b/style.css
@@ -73,6 +73,51 @@
   .card--water {
     background: #0047AB;
   }
+  .card--chaos {
+    background: #744e51;
+  }
+  .card--clarity {
+    background: #8e6d68;
+  }
+  .card--corruption {
+    background: #6b6754;
+  }
+  .card--courage {
+    background: #bd5b50;
+  }
+  .card--fear {
+    background: #b06f5f;
+  }
+  .card--ice {
+    background: #846060;
+  }
+  .card--luck {
+    background: #b37655;
+  }
+  .card--mirror {
+    background: #804746;
+  }
+  .card--peace {
+    background: #877b5a;
+  }
+  .card--smoke {
+    background: #75655a;
+  }
+  .card--time {
+    background: #a96146;
+  }
+  .card--war {
+    background: #9c4121;
+  }
+  .card--diversity {
+    background: #817168;
+  }
+  .card--assimilation {
+    background: #846d71;
+  }
+  .card--unity {
+    background: #996d7c;
+  }
 
   .card__top {
     display: flex;

--- a/style.css
+++ b/style.css
@@ -118,6 +118,15 @@
   .card--unity {
     background: #996d7c;
   }
+  .card--envy {
+    background: rgb(95, 108, 98);
+  }
+  .card--lust {
+    background: rgb(102, 79, 79);
+  }
+  .card--pride {
+    background: rgb(168, 147, 90);
+  }
 
   .card__top {
     display: flex;


### PR DESCRIPTION
The primary work has been a major content expansion (Main 2 and Aux 2 card sets), support for filtering by program, application of errata, and addition of new keywords. Added protocols for Main 3 and Aux 3, and cards that have been revealed for these programs.

### Program filter in the UI

- Added a new filter control to narrow cards by program (a set of protocols, e.g. "Main 1", "Aux 1")
- Refactored `index.html` and `script.js`, added CSS for the new filter
- Added "Expand All" / "Collapse All" buttons. All protocols are collapsed by default except Main 1.

<img width="453" height="574" alt="Screenshot 2026-05-05 at 16 01 56" src="https://github.com/user-attachments/assets/ca21b092-5ce8-4017-8b07-e0cbca21f23e" />

### New cards — Main 2, Aux 2 & Main 3 programs

- Expanded the dataset significantly: added new programs, protocols, and cards
- Added background color styling for the new card types - color selected by taking the [average color](https://avg-colour.netlify.app/) value of the image of the protocol card.
- Filled in full card text and keywords for all Main 2 and Aux 2 cards
- Partial list of cards from Main 3 added.

### Errata from Codex update

- Updated card text to match the official [Compile Codex](https://boardgamegeek.com/filepage/291919/compile-codex) errata from 22/9/25
- Added clarifications and rulings properties to card data objects (stored but not yet displayed in the UI)

### New keywords

- Added `compile`, `shuffle`, `top-deck`, and `trash` to the keyword glossary in both `index.html` and `script.js
`
- Added `control` keyword from Main 3 / Aux 3 set.

<img width="456" height="572" alt="Screenshot 2026-05-05 at 16 09 05" src="https://github.com/user-attachments/assets/82401e1b-896c-4729-9902-4039b413a56c" />

### Other

- Fixed some typos